### PR TITLE
Fix wrong return type

### DIFF
--- a/src/glHelper.h
+++ b/src/glHelper.h
@@ -21,7 +21,7 @@ public:
 		// Initialize GLFW
 		if (!glfwInit()) {
 			std::cerr << "Failed to initialize GLFW" << std::endl;
-			return false;
+			return nullptr;
 		}
 
 		// Set GLFW to not create an OpenGL context (version 330 core)


### PR DESCRIPTION
When running make on a Mac, the compilation fails as can be seen in the sreenshot.
<img width="1228" alt="Scherm­afbeelding 2023-11-21 om 18 18 17" src="https://github.com/jlartois/perlin-terrain/assets/68854162/6a56829f-3796-480e-bb91-275e36f51ce8">

This pr fixes that bug by replacing the false return with a nullptr return.